### PR TITLE
allow a custom generator function to override default generators.

### DIFF
--- a/tasks/jsonschema_faker.js
+++ b/tasks/jsonschema_faker.js
@@ -57,7 +57,7 @@ module.exports = function(grunt){
         _.each(options.external, function(externalOptions){
             var externalContent = grunt.file.readJSON(externalOptions.src);
             var collection = _.map(externalContent, externalOptions.map);
-            var generator = externalGenerators[externalOptions.generator];
+            var generator = typeof externalOptions.generator === 'function' ? externalOptions.generator : externalGenerators[externalOptions.generator];
             jsf.format(externalOptions.name, generator(collection));
         });
         var schema = grunt.file.readJSON(file);


### PR DESCRIPTION
So that users can do something like

```javascript
external: [
  {
     name: 'foo',
     generator: function (collection) {
       return function () { ... }
     },
     src: '...',
     map: function (item) { ...}
  }
]
```