### PR TITLE
Bump minor version

### DIFF
--- a/docs/jsonschema-faker-options.md
+++ b/docs/jsonschema-faker-options.md
@@ -39,7 +39,7 @@ The `external` option needs to be an array of objects, each of them needs to
 have following 4 fields defined:
 
  * *`name`*: `string`. This is just a name of the external source. It will be used in the JSON schema (as a `json-schema-faker` *custom format*)
- * *`generator`*: `string` [`random`|`cycle`]. Currently, two generators are provided, but you may write your own
+ * *`generator`*: `string`|`function`. Currently, the `string` option provides two generators (`random`|`cycle`), but you may use a `function` to provide your own custom [generator](https://github.com/json-schema-faker/grunt-jsonschema-faker/blob/master/generators.js).
  * *`src`*: `string`. Path to the external data source file.
  * *`map`*: `function`. This function will be used by [`_.map`](https://lodash.com/docs#map) to modify each element from the source file. You may return only the *id* of each source element, but you may as well need to return a complex structure to re-use.
 
@@ -66,5 +66,5 @@ keeping consistent relations between files.
    * it loads the content from `src` file
    * map all elements using given `map` function
    * creates a *closure* that will have access to the mapped collection.  The closure returns single values (which are products of `map`) and the strategy depends on `generator` used.
-   * the closure is registered as an ordinary [`json-schema-faker` custom format](https://github.com/json-schema-faker/json-schema-faker#custom-formats) using the `name` 
+   * the closure is registered as an ordinary [`json-schema-faker` custom format](https://github.com/json-schema-faker/json-schema-faker#custom-formats) using the `name`
    * the JSON schema will handle custom `name` format.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-jsonschema-faker",
   "description": "Grunt task generating fake data according to JSON schema",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "author": "Tomasz Ducin <tomasz@ducin.it>",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-jsonschema-faker",
   "description": "Grunt task generating fake data according to JSON schema",
-  "version": "0.4.0",
+  "version": "0.3.2",
   "author": "Tomasz Ducin <tomasz@ducin.it>",
   "repository": {
     "type": "git",

--- a/tasks/jsonschema_faker.js
+++ b/tasks/jsonschema_faker.js
@@ -57,7 +57,7 @@ module.exports = function(grunt){
         _.each(options.external, function(externalOptions){
             var externalContent = grunt.file.readJSON(externalOptions.src);
             var collection = _.map(externalContent, externalOptions.map);
-            var generator = externalGenerators[externalOptions.generator];
+            var generator = typeof externalOptions.generator === 'function' ? externalOptions.generator : externalGenerators[externalOptions.generator];
             jsf.format(externalOptions.name, generator(collection));
         });
         var schema = grunt.file.readJSON(file);


### PR DESCRIPTION
Trying this in favor of #22 so that running `npm publish` will include updated docs, semver, and custom generators.